### PR TITLE
feat: use max QFI value in a pdu session as GRE tunnel key

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,6 @@ LDFLAGS = -X github.com/free5gc/version.BUILD_TIME=$(BUILD_TIME) \
 
 n3iwue: clean
 	@echo "Start building $(@F)...."
-	go mod tidy
 	CGO_ENABLED=0 go build -gcflags "$(GCFLAGS)" -ldflags "$(LDFLAGS)" -o $(ROOT_PATH)/$@ $(@F).go
 
 debug: GCFLAGS += -N -l

--- a/config/n3ue.yaml
+++ b/config/n3ue.yaml
@@ -35,7 +35,7 @@ configuration:
             SQN: 16f3b3f71005
             AMF: 8000
             OP: b672047e003bb952dca6cb8af0e5b779
-            OPC: df0c67868fa25f748b7044c6e7c245b8
+            OPC: df0c67868fa25f748b7044c6e7c245b8 # not support
 logger:
     N3UE: # the kind of log output
         debugLevel: trace # how detailed to output, value: trace, debug, info, warn, error, fatal, panic

--- a/internal/gre/gre.go
+++ b/internal/gre/gre.go
@@ -21,7 +21,7 @@ func SetupGreTunnel(greIfaceName, parentIfaceName string, ueTunnelAddr, n3iwfTun
 	)
 
 	if qoSInfo != nil {
-		greKeyField |= (uint32(qoSInfo.QfiList[0]) & 0x3F) << 24
+		greKeyField |= (uint32(qoSInfo.MaxQFI()) & 0x3F) << 24
 	}
 
 	if parent, err = netlink.LinkByName(parentIfaceName); err != nil {

--- a/internal/qos/qos.go
+++ b/internal/qos/qos.go
@@ -35,3 +35,11 @@ func Parse5GQoSInfoNotify(n *message.Notification) (info *PDUQoSInfo, err error)
 
 	return
 }
+
+func (pduQosInfo PDUQoSInfo) MaxQFI() uint8 {
+	var maxQfi uint8 = 0
+	for _, qfi := range pduQosInfo.QfiList {
+		maxQfi = max(maxQfi, qfi)
+	}
+	return maxQfi
+}

--- a/pkg/procedure/Procedure.go
+++ b/pkg/procedure/Procedure.go
@@ -65,16 +65,20 @@ func StartProcedure() {
 				}
 			case context.PduSessionCreated:
 				AppLog.Info("PduSession Created")
-				if err := TestConnectivity("1.1.1.1"); err != nil {
-					AppLog.Errorf("ping fail 1.1.1.1: %+v", err)
-				}
-				if err := TestConnectivity("8.8.8.8"); err != nil {
-					AppLog.Errorf("ping fail 8.8.8.8: %+v", err)
+
+				pingDest := "1.1.1.1"
+				if err := TestConnectivity(pingDest); err != nil {
+					AppLog.Errorf("ping fail %s: %+v", pingDest, err)
 				} else {
-					logger.NASLog.Infof("ULCount=%x, DLCount=%x",
-						n3ueSelf.RanUeContext.ULCount.Get(),
-						n3ueSelf.RanUeContext.DLCount.Get())
-					AppLog.Info("Keep connection with N3IWF until receive SIGINT or SIGTERM")
+					pingDest = "8.8.8.8"
+					if err := TestConnectivity(pingDest); err != nil {
+						AppLog.Errorf("ping fail %s: %+v", pingDest, err)
+					} else {
+						logger.NASLog.Infof("ULCount=%x, DLCount=%x",
+							n3ueSelf.RanUeContext.ULCount.Get(),
+							n3ueSelf.RanUeContext.DLCount.Get())
+						AppLog.Info("Keep connection with N3IWF until receive SIGINT or SIGTERM")
+					}
 				}
 			}
 		}

--- a/pkg/procedure/Procedure.go
+++ b/pkg/procedure/Procedure.go
@@ -65,8 +65,11 @@ func StartProcedure() {
 				}
 			case context.PduSessionCreated:
 				AppLog.Info("PduSession Created")
+				if err := TestConnectivity("1.1.1.1"); err != nil {
+					AppLog.Errorf("ping fail 1.1.1.1: %+v", err)
+				}
 				if err := TestConnectivity("8.8.8.8"); err != nil {
-					AppLog.Errorf("ping fail : %+v", err)
+					AppLog.Errorf("ping fail 8.8.8.8: %+v", err)
 				} else {
 					logger.NASLog.Infof("ULCount=%x, DLCount=%x",
 						n3ueSelf.RanUeContext.ULCount.Get(),


### PR DESCRIPTION
## Description 
- Use max QFI value in PDU session as tunnel key

## Test Result
![截圖 2024-06-06 下午12 05 35](https://github.com/free5gc/n3iwf/assets/28786462/3b41e9aa-aac1-4567-aaa2-f49397789cc4)
- `1.1.1.1` has QFI = 3
- `8.8.8.8` has QFI = 1
- In this case, N3IWF would use **QFI = 3** in both GRE packet from `1.1.1.1` and `8.8.8.8` 

## Note
- https://github.com/free5gc/n3iwf/pull/34 