### PR TITLE
fix: IKEv2 IDi shall be random

### DIFF
--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -44,6 +44,7 @@ type N3UE struct {
 	RanUeContext         *security.RanUeContext
 	MobileIdentity5GS    nasType.MobileIdentity5GS
 	IkeInitiatorSPI      uint64
+	IkeIDInitiator       []byte
 	Secert               *big.Int
 	Factor               *big.Int
 	Proposal             *message.Proposal

--- a/pkg/ike/handler.go
+++ b/pkg/ike/handler.go
@@ -503,7 +503,8 @@ func (s *Server) handleIKEAUTH(
 		}
 
 		var idPayload ike_message.IKEPayloadContainer
-		idPayload.BuildIdentificationInitiator(ike_message.ID_KEY_ID, []byte("UE"))
+		idInitiator := n3ueSelf.IkeIDInitiator
+		idPayload.BuildIdentificationInitiator(ike_message.ID_KEY_ID, idInitiator)
 		idPayloadData, err := idPayload.Encode()
 		if err != nil {
 			ikeLog.Errorln(err)

--- a/pkg/ike/send.go
+++ b/pkg/ike/send.go
@@ -137,7 +137,16 @@ func (s *Server) SendIkeAuth() {
 	var ikePayload ike_message.IKEPayloadContainer
 
 	// Identification
-	ikePayload.BuildIdentificationInitiator(ike_message.ID_KEY_ID, []byte("UE"))
+	idByte := make([]byte, 8)
+	id, err := ike_security.GenerateRandomNumber()
+	if err != nil {
+		ikeLog.Errorf("error generating IDi: %d", err)
+		return
+	}
+
+	binary.BigEndian.PutUint64(idByte, id.Uint64())
+	ikePayload.BuildIdentificationInitiator(ike_message.ID_KEY_ID, idByte)
+	n3ueContext.IkeIDInitiator = idByte
 
 	// Security Association
 	n3ueContext.SecurityAssociation = ikePayload.BuildSecurityAssociation()
@@ -196,7 +205,7 @@ func (s *Server) SendIkeAuth() {
 		n3ueContext.N3IWFUe.IKEConnection = n3ueContext.IKEConnection[4500]
 	}
 
-	err := s.SendIkeMsgToN3iwf(
+	err = s.SendIkeMsgToN3iwf(
 		n3ueContext.N3IWFUe.IKEConnection,
 		ikeMessage,
 		n3ueContext.N3IWFUe.N3IWFIKESecurityAssociation)


### PR DESCRIPTION
### Summary
TS 33.501 Section 7.2.1 specifies that the UE shall set the ID initiator (**IDi**) payload to the ID_KEY_ID type in the first IKE_AUTH message, and that its value shall be an arbitrary random number. Currently, the `n3iwue` uses the hardcoded string "UE" as the IDi value.

This pull request updates the `n3iwue` by replacing the hardcoded value with a randomly generated uint64, using the _GenerateRandomNumber()_ function. The generated value is also stored in the n3ue internal context and used later for authentication.

### Validation
Tested with Free5GC v4.2.2 (commit eef1d0fe9867c245673d2e2345eeff79c48e04ef).

    